### PR TITLE
Patch:  Search results rendered in JSON to use application/json as the Content-Type in every case

### DIFF
--- a/src/main/webapp/WEB-INF/views/search/list.json.jspx
+++ b/src/main/webapp/WEB-INF/views/search/list.json.jspx
@@ -1,5 +1,5 @@
 <jsp:root xmlns:fmt="http://java.sun.com/jsp/jstl/fmt" xmlns:eaccpf="urn:jsptagdir:/WEB-INF/tags/eac_cpf" xmlns:jsp="http://java.sun.com/JSP/Page" xmlns:util="urn:jsptagdir:/WEB-INF/tags/util" xmlns:fn="http://java.sun.com/jsp/jstl/functions" xmlns:spring="http://www.springframework.org/tags" xmlns:c="http://java.sun.com/jsp/jstl/core" version="2.0"><jsp:output omit-xml-declaration="yes"/><c:set var="baseURL" value="${fn:replace(requestURL, pageContext.request.requestURI, pageContext.request.contextPath)}" /><c:set var="recNum" value="0" />
-{"thisPage": ${page},
+<jsp:directive.page contentType="application/json" />{"thisPage": ${page},
  "totalResults": ${count},
  "perPage": ${size},  
  "obj":[ <c:forEach items="${seriesitems}" var="result">{"category": "${result.type}","title": "${fn:escapeXml(result.title)}","id": "${baseURL}${result.url}","summary": "${fn:escapeXml(result.escapedContent)}"}<c:set var="recNum" value="${recNum + 1}" /><c:if test="${(recNum lt count) and (recNum lt size)}">,</c:if></c:forEach>]}


### PR DESCRIPTION
Requests for search results in JSON now bear the correct Content-Type header. The media type is correctly determined by SimpleMediaTypeView, however it was not being sent from api.records.nsw.gov.au or in testing.
